### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<bundle.namespace>org.cytoscape.biopax.internal</bundle.namespace>
 		<cytoscape.api.version>3.3.0</cytoscape.api.version>
 		<osgi.api.version>4.2.0</osgi.api.version>
-		<paxtools.version>5.0.0-SNAPSHOT</paxtools.version>
+		<paxtools.version>5.0.1</paxtools.version>
 		<junit.version>4.12</junit.version>
 		<maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
 		<maven-bundle-plugin.version>2.5.4</maven-bundle-plugin.version>


### PR DESCRIPTION
Updated Paxtools dependency version to 5.0.1 release, which is already available in the Maven Central.